### PR TITLE
Removing mako-sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ mako()
 
 Create a new plugin instance, with the following `options` available:
 
- - `root` the root for the project, paths will be set relative to here (default: `process.cwd()`)
  - `extensions` the list of extensions **in addition to** `.css` to resolve (eg: `.less`, `.sass`)
  - `resolveOptions` additional options to be passed to [resolve](https://www.npmjs.com/package/resolve)
+ - `root` the root for the project, paths will be set relative to here (default: `process.cwd()`)
+ - `sourceMaps` specify `true` to enable source-maps (default: `false`)
+ - `sourceRoot` specifies the path used as the source map root (default: `"mako://"`)
 
 ### css.images
 
@@ -79,7 +81,13 @@ array directly, but for core support of other types, please open an issue.
 During **analyze**, this will parse CSS files for `@import` statements and `url(...)` links, which
 will be resolved via [resolve](https://www.npmjs.com/package/resolve).
 
-During **build**, each _entry_ CSS file will have all of it's dependencies bundled into a single
+During **assemble**, each _entry_ CSS file will have all of it's dependencies bundled into a single
 file. Along the way, those dependencies will be _removed_ from the tree, leaving only the output
 files behind. The assets, however, will remain in the tree, with their link being moved to the
 entry files that use them.
+
+## About Source Maps
+
+By enabling source-maps with `sourceMaps: true`, this simply generates `file.sourcemap` which is a plain
+object with the source-map metadata. Use another plugin such as [mako-sourcemaps](https://github.com/makojs/sourcemaps)
+to take this object and write it to an external file or as an inline comment.

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ let path = require('path');
 let resolve = require('browser-resolve');
 let rework = require('rework');
 let rewrite = require('rework-plugin-url');
-let sourcemaps = require('mako-sourcemaps');
 let strip = require('strip-extension');
 let without = require('array-without');
 
@@ -56,10 +55,6 @@ function plugin(options) {
     mako.dependencies('css', npm);
     mako.postdependencies('css', pack);
     mako.postdependencies([ plugin.images, plugin.fonts ], move);
-
-    if (config.sourceMaps) {
-      mako.use(sourcemaps('css', { inline: config.sourceMaps === 'inline' }));
-    }
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "file-deps": "0.0.11",
     "is-datauri": "^0.1.0",
     "is-url": "^1.2.1",
-    "mako-sourcemaps": "^0.1.0",
     "rework": "^1.0.1",
     "rework-custom-import": "^0.1.0",
     "rework-plugin-url": "^1.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 let chai = require('chai');
+let convert = require('convert-source-map');
 let css = require('..');
 let deps = require('file-deps');
 let fs = require('fs');
@@ -239,29 +240,15 @@ describe('css plugin', function () {
     });
 
     context('.sourceMaps', function () {
-      it('should render inline source maps', function () {
+      it('should generate file.sourcemap', function () {
         let entry = fixture('source-maps-inline/index.css');
-
-        return mako()
-          .use(plugins({ sourceMaps: 'inline' }))
-          .build(entry)
-          .then(function (build) {
-            let file = build.tree.getFile(entry);
-            assert.strictEqual(file.contents.trim(), expected('source-maps-inline'));
-          });
-      });
-
-      it('should render external source maps', function () {
-        let entry = fixture('source-maps/index.css');
 
         return mako()
           .use(plugins({ sourceMaps: true }))
           .build(entry)
           .then(function (build) {
-            let css = build.tree.getFile(entry);
-            let map = build.tree.getFile(`${entry}.map`);
-            assert.strictEqual(css.contents.trim(), expected('source-maps', 'css'));
-            assert.strictEqual(map.contents.trim(), expected('source-maps', 'map'));
+            let file = build.tree.getFile(entry);
+            assert(convert.fromObject(file.sourcemap), 'expected valid source-map object');
           });
       });
     });


### PR DESCRIPTION
This removes mako-sourcemaps from the internals of mako-css. (fixes #16) This should instead be added by a plugin bundle or manually by a user. (mako-browser will include this as well)